### PR TITLE
Player feat (#118)

### DIFF
--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -60,7 +60,8 @@ const handleENOENTError = err => {
  * @returns {Object} AppError object
  */
 const handleOAuthError = err => {
-  return new AppError(err.message, err.oauthError.statusCode);
+
+  return new AppError(err.message, err.oauthError.statusCode ? err.oauthError.statusCode : err.oauthError);
 };
 
 /**

--- a/src/models/playHistory.model.js
+++ b/src/models/playHistory.model.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const mongooseLeanVirtuals = require('mongoose-lean-virtuals');
 
 const playHistorySchema = mongoose.Schema({
   user: {
@@ -10,10 +11,12 @@ const playHistorySchema = mongoose.Schema({
   context: {
     type: {
       type: String,
+      required: true,
       enum: ['Album', 'Artist', 'Playlist']
     },
     item: {
       type: mongoose.Types.ObjectId,
+      required: true,
       refPath: 'context.type'
     }
   },
@@ -31,6 +34,15 @@ const playHistorySchema = mongoose.Schema({
 });
 
 playHistorySchema.index({ user: 1, playedAt: 1 });
+
+playHistorySchema.virtual('context.id').get(function () {
+  if (this.context.item && this.context.item._id)
+    return this.context.item._id;
+  else
+    return this.context.item;
+});
+
+playHistorySchema.plugin(mongooseLeanVirtuals);
 
 const PlayHistory = mongoose.model('PlayHistory', playHistorySchema);
 

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -98,12 +98,10 @@ const userSchema = mongoose.Schema(
       required: [true, 'Please Enter your Country!']
     },
     facebook_id: {
-      type: String,
-      select: false
+      type: String
     },
     google_id: {
-      type: String,
-      select: false
+      type: String
     },
     verifyToken: {
       type: String,

--- a/src/services/player.service.js
+++ b/src/services/player.service.js
@@ -263,11 +263,12 @@ const startPlayingFromOffset = async (player, queue, offset, queues) => {
  * @param {Number} progressMs progress in m Second 
  * @param {Array<String>} queues queues IDs array
  * @param {Document} [track] Currently playing track
+ * @param {Document} [queue] Currently playing queue
  * @description Set player.progressMs to the given progressMs and if progressMs >= track duration (go next if repeat state != track else start the track from zero second)
  * @summary Chnage player progress
  * @returns {Document} player
  */
-const changePlayerProgress = async (player, progressMs, queues, track = null) => {
+const changePlayerProgress = async (player, progressMs, queues, track = null, queue = null) => {
   const queueService = require('./queue.service');
   player.progressMs = progressMs;
 
@@ -277,7 +278,8 @@ const changePlayerProgress = async (player, progressMs, queues, track = null) =>
   // if position >= track duration go to next
   if (track && progressMs >= track.duration) {
     if (player.repeatState !== 'track') {
-      let queue = await queueService.getQueueById(queues[0], { selectDetails: true });
+      if (!queue)
+        queue = await queueService.getQueueById(queues[0], { selectDetails: true });
 
       if (!queue || !queue.tracks || !queue.tracks.length) {
         return null;

--- a/tests/utils/models/playHistory.model.mocks.js
+++ b/tests/utils/models/playHistory.model.mocks.js
@@ -7,8 +7,8 @@ const createFakePlayHistory = () => {
     user: mongoose.Types.ObjectId(),
     track: mongoose.Types.ObjectId(),
     context: {
-      type: 'album',
-      id: mongoose.Types.ObjectId()
+      type: 'Album',
+      item: mongoose.Types.ObjectId()
     },
     playedAt: Date.now()
   });


### PR DESCRIPTION
* Refactor with add track to player

* Add increase track views feature

* Improve play artist context

* Get currently playing with lean

* Add feature : previous while playing the first track go to the last queue if found

* Add create queue from related artists

* create queue from realted albums

* Add create queue from related playlist

* Create queue from list of tracks

* Add seeds eminem & sadat

* Add marwan moussa seeds

* Add abyusif seeds

* Add adele seeds

* Ellie goulding seeds

* Add travis seeds

* Done artists seeds

* Create user Liked Songs

* Remove trackService from playerService

* Add lean to queue service

* Add plan date to prem users

* Add Best OF EMINEM playlist

* Add Ad model

* Add onModel to player

* Add play ad

* Fix tests

* Done ads

* Handle playing ad case

* Add time to logger

* Add standard apache logger

* Fix optional Auth

* handle ENOENT error

* error functional documentation

* Add loggly to production

* Set actions in addTrackToPlayer

* Done playhistory

* Add lean to get player

* Revert "Add lean to get player"

This reverts commit d5fbb64ea85e5414d5ae2081472fe17a06b4bdc2.

* Add lean to currently playing

* Run loggly only when token is valid and production

* Change onModel to itemModel

* Add lean to player

* Fix merge

* Edit Loggly logs config to be optional

* Replace LOGGY with LOGGLY

* Fix audioUrl split

* Fix resume player queue index

* Add queue to change player progress

* Add id to playhistory context

* Remove select false from facebook_id and google_id

* Delete console log from playhistory test

* Fix error handling for oAuth

* Remove catchAsync

Co-authored-by: Hassan <hmibrahim1999@gmail.com>