### PR TITLE
Fix adsCounter in premium endpoints

### DIFF
--- a/src/models/player.model.js
+++ b/src/models/player.model.js
@@ -54,7 +54,8 @@ const playerSchema = mongoose.Schema({
     }
   },
   adsCounter: {
-    type: Number
+    type: Number,
+    default: undefined
   },
   actions: {
     type: Object

--- a/src/services/player.service.js
+++ b/src/services/player.service.js
@@ -135,6 +135,7 @@ const addTrackToPlayer = async (player, track, context = { type: undefined, id: 
   // increase track views
   Track.findByIdAndUpdate({ _id: track }, { $inc: { views: 1 } }).exec();
   // handle ads counter
+  if (player.adsCounter === null) player.adsCounter = undefined; // fix converting undefined to null in update query
   if (player.adsCounter !== undefined && player.item !== track) {
     player.adsCounter++;
   }

--- a/src/services/premium.service.js
+++ b/src/services/premium.service.js
@@ -37,7 +37,7 @@ exports.subscribe = async user => {
   }
 
   // set player ads to undefined
-  await Player.findOneAndUpdate({ userId: user._id }, { $set: { adsCounter: undefined } });
+  await Player.findOneAndUpdate({ userId: user._id }, { $unset: { adsCounter: undefined } });
 
   // Update User
   return await Normal.findOneAndUpdate(


### PR DESCRIPTION
* Refactor with add track to player

* Add increase track views feature

* Improve play artist context

* Get currently playing with lean

* Add feature : previous while playing the first track go to the last queue if found

* Add create queue from related artists

* create queue from realted albums

* Add create queue from related playlist

* Create queue from list of tracks

* Add seeds eminem & sadat

* Add marwan moussa seeds

* Add abyusif seeds

* Add adele seeds

* Ellie goulding seeds

* Add travis seeds

* Done artists seeds

* Create user Liked Songs

* Remove trackService from playerService

* Add lean to queue service

* Add plan date to prem users

* Add Best OF EMINEM playlist

* Add Ad model

* Add onModel to player

* Add play ad

* Fix tests

* Done ads

* Handle playing ad case

* Add time to logger

* Add standard apache logger

* Fix optional Auth

* handle ENOENT error

* error functional documentation

* Add loggly to production

* Set actions in addTrackToPlayer

* Done playhistory

* Add lean to get player

* Revert "Add lean to get player"

This reverts commit d5fbb64ea85e5414d5ae2081472fe17a06b4bdc2.

* Add lean to currently playing

* Run loggly only when token is valid and production

* Change onModel to itemModel

* Add lean to player

* Fix merge

* Edit Loggly logs config to be optional

* Replace LOGGY with LOGGLY

* Fix audioUrl split

* Fix resume player queue index

* Add queue to change player progress

* Add id to playhistory context

* Remove select false from facebook_id and google_id

* Delete console log from playhistory test

* Fix error handling for oAuth

* Remove catchAsync

* fix converting undefined to null in update query

* Use unset instead of set

Co-authored-by: Hassan <hmibrahim1999@gmail.com>